### PR TITLE
Feature implementation from commits 873bcdf..2e83cfb

### DIFF
--- a/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/ProcessInstance.java
+++ b/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/ProcessInstance.java
@@ -53,4 +53,6 @@ public interface ProcessInstance extends ApplicationElement {
 
     String getProcessDefinitionName();
 
+    String getRootProcessInstanceId();
+
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessInstanceImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessInstanceImpl.java
@@ -34,6 +34,7 @@ public class ProcessInstanceImpl extends ApplicationElementImpl implements Proce
     private String parentId;
     private Integer processDefinitionVersion;
     private String processDefinitionName;
+    private String rootProcessInstanceId;
 
     public ProcessInstanceImpl() {
     }
@@ -98,6 +99,11 @@ public class ProcessInstanceImpl extends ApplicationElementImpl implements Proce
         return processDefinitionName;
     }
 
+    @Override
+    public String getRootProcessInstanceId() {
+        return rootProcessInstanceId;
+    }
+
     public void setId(String id) {
         this.id = id;
     }
@@ -144,6 +150,10 @@ public class ProcessInstanceImpl extends ApplicationElementImpl implements Proce
 
     public void setProcessDefinitionName(String processDefinitionName) {
         this.processDefinitionName = processDefinitionName;
+    }
+
+    public void setRootProcessInstanceId(String rootProcessInstanceId) {
+        this.rootProcessInstanceId = rootProcessInstanceId;
     }
 
     @Override

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
@@ -130,7 +130,7 @@ public class ProcessAdminRuntimeImpl implements ProcessAdminRuntime {
         if (getProcessDefinitionsPayload.hasDefinitionKeys()) {
             processDefinitionQuery.processDefinitionKeys(getProcessDefinitionsPayload.getProcessDefinitionKeys());
         }
-        return new PageImpl<>(processDefinitionConverter.from(processDefinitionQuery.list()),
+        return new PageImpl<>(processDefinitionConverter.from(processDefinitionQuery.listPage(pageable.getStartIndex(), pageable.getMaxItems())),
             Math.toIntExact(processDefinitionQuery.count()));
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -217,7 +217,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
             processDefinitionQuery.processDefinitionKeys(getProcessDefinitionsPayload.getProcessDefinitionKeys());
         }
 
-        return new PageImpl<>(processDefinitionConverter.from(processDefinitionQuery.list()),
+        return new PageImpl<>(processDefinitionConverter.from(processDefinitionQuery.listPage(pageable.getStartIndex(), pageable.getMaxItems())),
                               Math.toIntExact(processDefinitionQuery.count()));
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverter.java
@@ -40,6 +40,7 @@ public class APIProcessInstanceConverter extends ListConverter<org.activiti.engi
         processInstance.setProcessDefinitionVersion(internalProcessInstance.getProcessDefinitionVersion());
         processInstance.setAppVersion(Objects.toString(internalProcessInstance.getAppVersion(), null));
         processInstance.setProcessDefinitionName(internalProcessInstance.getProcessDefinitionName());
+        processInstance.setRootProcessInstanceId(internalProcessInstance.getRootProcessInstanceId());
         return processInstance;
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImplTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.runtime.api.impl;
+
+import org.activiti.api.runtime.shared.query.Pageable;
+import org.activiti.core.common.spring.security.policies.ProcessSecurityPoliciesManager;
+import org.activiti.engine.RuntimeService;
+import org.activiti.engine.impl.RepositoryServiceImpl;
+import org.activiti.engine.impl.interceptor.CommandExecutor;
+import org.activiti.engine.repository.ProcessDefinitionQuery;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessAdminRuntimeImplTest {
+
+    private ProcessAdminRuntimeImpl processAdminRuntime;
+
+    @Mock
+    private ProcessSecurityPoliciesManager securityPoliciesManager;
+
+    @Mock
+    private CommandExecutor commandExecutor;
+
+    @Mock
+    private RuntimeService runtimeService;
+
+    @Mock
+    private APIProcessInstanceConverter processInstanceConverter;
+
+    @Mock
+    private ProcessVariablesPayloadValidator processVariableValidator;
+
+    @Mock
+    private APIProcessDefinitionConverter processDefinitionConverter;
+
+
+    private RepositoryServiceImpl repositoryService;
+
+    @BeforeEach
+    void setUp() {
+        repositoryService = spy(new RepositoryServiceImpl());
+        repositoryService.setCommandExecutor(commandExecutor);
+
+        processAdminRuntime = spy(new ProcessAdminRuntimeImpl(repositoryService,
+            processDefinitionConverter,
+            runtimeService,
+            processInstanceConverter,
+            null,
+            null,
+            processVariableValidator));
+
+    }
+
+    @Test
+    void should_applyPaginationParams_whenSearchingProcessDefinitions() {
+
+        ProcessDefinitionQuery processDefinitionQuery = mock(ProcessDefinitionQuery.class, Answers.RETURNS_SELF);
+        given(repositoryService.createProcessDefinitionQuery()).willReturn(processDefinitionQuery);
+        given(processDefinitionQuery.listPage(0, 2)).willReturn(Collections.emptyList());
+
+        processAdminRuntime.processDefinitions(Pageable.of(0, 2));
+
+        verify(processDefinitionQuery).listPage(0, 2);
+    }
+
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
@@ -41,6 +41,7 @@ public class APIProcessInstanceConverterTest {
     private static final String APP_VERSION_STRING = "1";
     private static final Date START_TIME = new Date();
     private static final String PROCESS_DEFINITION_NAME = "processDefinitionName";
+    private static final String ROOT_PROCESS_INSTANCE_ID = "rootProcessInstanceId";
 
     private APIProcessInstanceConverter subject = new APIProcessInstanceConverter();
 
@@ -115,6 +116,7 @@ public class APIProcessInstanceConverterTest {
         assertThat(result.getStartDate()).isEqualTo(START_TIME);
         assertThat(result.getAppVersion()).isEqualTo(appVersionString);
         assertThat(result.getProcessDefinitionName()).isEqualTo(PROCESS_DEFINITION_NAME);
+        assertThat(result.getRootProcessInstanceId()).isEqualTo(ROOT_PROCESS_INSTANCE_ID);
     }
 
     private ExecutionEntity anInternalProcessInstance(Integer appVersion) {
@@ -133,6 +135,7 @@ public class APIProcessInstanceConverterTest {
         internalProcessInstance.setActive(true);
         internalProcessInstance.setAppVersion(appVersion);
         internalProcessInstance.setProcessDefinitionName(PROCESS_DEFINITION_NAME);
+        internalProcessInstance.setRootProcessInstanceId(ROOT_PROCESS_INSTANCE_ID);
 
         return internalProcessInstance;
     }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/resources/jsonPatch/jsonPatch-in-mapping-output.json
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/resources/jsonPatch/jsonPatch-in-mapping-output.json
@@ -16,7 +16,15 @@
           "type": "json",
           "required": false,
           "value": {
-            "firstname": "Bob"
+            "firstname": "Bob",
+            "addresses": [
+              {
+                "street": "123 Main St"
+              },
+              {
+                "street": "456 Elm St"
+              }
+            ]
           }
         },
         "variable-empty-json-id": {
@@ -71,6 +79,21 @@
                   "op": "add",
                   "path": "/lastname",
                   "value": "${process_variable_lastname}"
+                },
+                {
+                  "op": "add",
+                  "path": "/addresses/1/street",
+                  "value": "${process_variable_address.address.street}"
+                },
+                {
+                  "op": "add",
+                  "path": "/addresses/1/new-field",
+                  "value": "${process_variable_name}"
+                },
+                {
+                  "op": "add",
+                  "path": "/addresses/2",
+                  "value": "${process_variable_address}"
                 }
               ]
             },

--- a/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/export/MultiInstanceExport.java
+++ b/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/export/MultiInstanceExport.java
@@ -23,46 +23,49 @@ import org.activiti.bpmn.model.MultiInstanceLoopCharacteristics;
 import org.apache.commons.lang3.StringUtils;
 
 public class MultiInstanceExport implements BpmnXMLConstants {
+    public static void writeMultiInstance(Activity activity, XMLStreamWriter xtw) throws Exception {
+        if (activity == null || activity.getLoopCharacteristics() == null) {
+            return;
+        }
 
-  public static void writeMultiInstance(Activity activity, XMLStreamWriter xtw) throws Exception {
-    if (activity.getLoopCharacteristics() != null) {
-      MultiInstanceLoopCharacteristics multiInstanceObject = activity.getLoopCharacteristics();
-      if (multiInstanceObject!=null) {
-          xtw.writeStartElement(ELEMENT_MULTIINSTANCE);
-          BpmnXMLUtil.writeDefaultAttribute(ATTRIBUTE_MULTIINSTANCE_SEQUENTIAL,
-              String.valueOf(multiInstanceObject.isSequential()).toLowerCase(), xtw);
-          if (StringUtils.isNotEmpty(multiInstanceObject.getInputDataItem())) {
-              BpmnXMLUtil.writeQualifiedAttribute(ATTRIBUTE_MULTIINSTANCE_COLLECTION,
-                  multiInstanceObject.getInputDataItem(), xtw);
-          }
-          if (StringUtils.isNotEmpty(multiInstanceObject.getElementVariable())) {
-              BpmnXMLUtil.writeQualifiedAttribute(ATTRIBUTE_MULTIINSTANCE_VARIABLE,
-                  multiInstanceObject.getElementVariable(), xtw);
-          }
-          if (StringUtils.isNotEmpty(multiInstanceObject.getLoopCardinality())) {
-              xtw.writeStartElement(ELEMENT_MULTIINSTANCE_CARDINALITY);
-              xtw.writeCharacters(multiInstanceObject.getLoopCardinality());
-              xtw.writeEndElement();
-          }
-          if (StringUtils.isNotEmpty(multiInstanceObject.getLoopDataOutputRef())) {
-              xtw.writeStartElement(ELEMENT_MULTI_INSTANCE_DATA_OUTPUT);
-              xtw.writeCharacters(multiInstanceObject.getLoopDataOutputRef());
-              xtw.writeEndElement();
-          }
-          if (StringUtils.isNotEmpty(multiInstanceObject.getOutputDataItem())) {
-              xtw.writeStartElement(ELEMENT_MULTI_INSTANCE_OUTPUT_DATA_ITEM);
-              xtw.writeAttribute(ATTRIBUTE_NAME, multiInstanceObject.getOutputDataItem());
-              xtw.writeEndElement();
-          }
-          if (StringUtils.isNotEmpty(multiInstanceObject.getCompletionCondition())) {
-              xtw.writeStartElement(ELEMENT_MULTIINSTANCE_CONDITION);
-              xtw.writeCharacters(multiInstanceObject.getCompletionCondition());
-              xtw.writeEndElement();
-          }
-          xtw.writeEndElement();
-      }
+        MultiInstanceLoopCharacteristics multiInstanceObject = activity.getLoopCharacteristics();
 
+        xtw.writeStartElement(BPMN2_PREFIX, ELEMENT_MULTIINSTANCE, BPMN2_NAMESPACE);
+
+        BpmnXMLUtil.writeDefaultAttribute(ATTRIBUTE_MULTIINSTANCE_SEQUENTIAL,
+            String.valueOf(multiInstanceObject.isSequential()).toLowerCase(), xtw);
+
+        writeAttributeIfNotEmpty(ATTRIBUTE_MULTIINSTANCE_COLLECTION, multiInstanceObject.getInputDataItem(), xtw);
+        writeAttributeIfNotEmpty(ATTRIBUTE_MULTIINSTANCE_VARIABLE, multiInstanceObject.getElementVariable(), xtw);
+        writeAttributeIfNotEmpty(ATTRIBUTE_MULTIINSTANCE_INDEX_VARIABLE, multiInstanceObject.getElementIndexVariable(), xtw);
+
+        writeElementIfNotEmpty(ELEMENT_MULTIINSTANCE_CARDINALITY, multiInstanceObject.getLoopCardinality(), xtw);
+        writeElementIfNotEmpty(ELEMENT_MULTI_INSTANCE_DATA_OUTPUT, multiInstanceObject.getLoopDataOutputRef(), xtw);
+
+        if (StringUtils.isNotEmpty(multiInstanceObject.getOutputDataItem())) {
+            xtw.writeStartElement(BPMN2_PREFIX, ELEMENT_MULTI_INSTANCE_OUTPUT_DATA_ITEM, BPMN2_NAMESPACE);
+            xtw.writeAttribute(ATTRIBUTE_NAME, multiInstanceObject.getOutputDataItem());
+            xtw.writeEndElement();
+        }
+
+        writeElementIfNotEmpty(ELEMENT_MULTIINSTANCE_CONDITION, multiInstanceObject.getCompletionCondition(), xtw);
+
+        xtw.writeEndElement();
     }
-  }
+
+
+    private static void writeAttributeIfNotEmpty(String attributeName, String value, XMLStreamWriter xtw) throws Exception {
+        if (StringUtils.isNotEmpty(value)) {
+            BpmnXMLUtil.writeQualifiedAttribute(attributeName, value, xtw);
+        }
+    }
+
+    private static void writeElementIfNotEmpty(String elementName, String value, XMLStreamWriter xtw) throws Exception {
+        if (StringUtils.isNotEmpty(value)) {
+            xtw.writeStartElement(BPMN2_PREFIX, elementName, BPMN2_NAMESPACE);
+            xtw.writeCharacters(value);
+            xtw.writeEndElement();
+        }
+    }
 
 }

--- a/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MultiInstanceUserTaskConverterTest.java
+++ b/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MultiInstanceUserTaskConverterTest.java
@@ -23,6 +23,8 @@ import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.UserTask;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 public class MultiInstanceUserTaskConverterTest extends AbstractConverterTest {
 
     @Test
@@ -54,11 +56,11 @@ public class MultiInstanceUserTaskConverterTest extends AbstractConverterTest {
     private void checkXml(BpmnModel model) throws Exception {
 
         String xml = new String(new BpmnXMLConverter().convertToXML(model),
-                                "UTF-8");
+            StandardCharsets.UTF_8);
 
         assertThat(xml).containsSubsequence("incoming>SequenceFlow_0c6mbti<",
                                             "outgoing>SequenceFlow_0pj9a04<",
-                                            "<multiInstanceLoopCharacteristics");
+                                            "<bpmn2:multiInstanceLoopCharacteristics");
 
     }
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/ManagedAsyncJobExecutor.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/ManagedAsyncJobExecutor.java
@@ -20,14 +20,13 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.concurrent.ManagedThreadFactory;
+import jakarta.enterprise.concurrent.ManagedThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Simple JSR-236 async job executor to allocate threads through {@link ManagedThreadFactory}. Falls back to {@link AsyncExecutor} when a thread factory was not referenced in configuration.
- *
  * In Java EE 7, all application servers should provide access to a {@link ManagedThreadFactory}.
  *
  */

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CompleteTaskCmd.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CompleteTaskCmd.java
@@ -89,5 +89,8 @@ public class CompleteTaskCmd extends AbstractCompleteTaskCmd {
     this.taskVariables = taskVariables;
   }
 
+  public String getTaskId() {
+    return taskId;
+  }
 
 }

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/InitiatorTest.testInitiatorWithinCallActivitySubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/InitiatorTest.testInitiatorWithinCallActivitySubProcess.bpmn20.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:activiti="http://activiti.org/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0g0v7px" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta.7">
+  <bpmn:process id="CallActivityWithInitiatorSubprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_03ffo1t</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_03ffo1t" sourceRef="StartEvent_1" targetRef="callActivity" />
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:incoming>SequenceFlow_1qpm1uw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1qpm1uw" sourceRef="callActivity" targetRef="EndEvent" />
+    <bpmn:callActivity id="callActivity" name="Call SubProcess with Initiator Task" activiti:async="true" calledElement="InitiatorProcess">
+      <bpmn:incoming>SequenceFlow_03ffo1t</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1qpm1uw</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CallActivityWithInitiatorSubprocess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_03ffo1t_di" bpmnElement="SequenceFlow_03ffo1t">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="265" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_07jpo0n_di" bpmnElement="EndEvent">
+        <dc:Bounds x="415" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1qpm1uw_di" bpmnElement="SequenceFlow_1qpm1uw">
+        <di:waypoint x="365" y="121" />
+        <di:waypoint x="415" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_09t3rnr_di" bpmnElement="callActivity">
+        <dc:Bounds x="265" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCandidateStartersIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCandidateStartersIT.java
@@ -61,7 +61,7 @@ public class ProcessRuntimeCandidateStartersIT {
         loginAsCandidateStarterUser();
 
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
-                                                                                                      50));
+                                                                                                      200));
         assertThat(processDefinitionPage.getContent()).isNotNull();
         assertThat(processDefinitionPage.getContent()) // All processes except UnstartableProcess
             .hasSize((int) repositoryService.createProcessDefinitionQuery().count() -1);
@@ -72,7 +72,7 @@ public class ProcessRuntimeCandidateStartersIT {
         loginAsGroupMemberCandidateStarter();
 
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
-            50));
+            200));
         assertThat(processDefinitionPage.getContent()).isNotNull();
         assertThat(processDefinitionPage.getContent()) // All processes except UnstartableProcess
             .hasSize((int) repositoryService.createProcessDefinitionQuery().count() -1);
@@ -83,7 +83,7 @@ public class ProcessRuntimeCandidateStartersIT {
         loginAsANonCandidateStarter();
 
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
-            50));
+            200));
         assertThat(processDefinitionPage.getContent()).isNotNull();
         // All processes except SingleTaskProcessRestricted and UnstartableProcess
         assertThat(processDefinitionPage.getContent())

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
@@ -83,7 +83,7 @@ public class ProcessRuntimeIT {
     private static final String SUPER_PROCESS = "superProcess";
     private static final String TWO_TASKS_PROCESS = "twoTaskProcess";
     private static final Pageable PAGEABLE = Pageable.of(0,
-        50);
+        200);
     public static final String CATEGORIZE_HUMAN_PROCESS_CATEGORY = "test-category";
 
     @Autowired
@@ -694,7 +694,7 @@ public class ProcessRuntimeIT {
         securityUtil.logInAs("admin");
 
         Page<ProcessDefinition> processDefinitionPage = processAdminRuntime.processDefinitions(Pageable.of(0,
-                50));
+                200));
         assertThat(processDefinitionPage.getContent()).isNotNull();
         assertThat(processDefinitionPage.getContent()).extracting(ProcessDefinition::getKey)
                 .contains(CATEGORIZE_HUMAN_PROCESS);
@@ -1072,7 +1072,7 @@ public class ProcessRuntimeIT {
         securityUtil.logInAs("manager");
 
         Page<ProcessInstance> processInstancePage = processAdminRuntime.processInstances(Pageable.of(0,
-            50));
+            200));
 
         assertThat(processInstancePage).isNotNull();
     }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeSecurityPoliciesIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeSecurityPoliciesIT.java
@@ -69,7 +69,7 @@ public class ProcessRuntimeSecurityPoliciesIT {
         securityUtil.logInAs("admin");
 
         Page<ProcessDefinition> processDefinitionPage = processAdminRuntime.processDefinitions(Pageable.of(0,
-                50));
+                200));
         assertThat(processDefinitionPage.getContent()).isNotNull();
         assertThat(processDefinitionPage.getContent())
                 .extracting(ProcessDefinition::getKey)

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskVariablesLocalCopiesTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskVariablesLocalCopiesTest.java
@@ -81,7 +81,7 @@ public class TaskVariablesLocalCopiesTest {
         securityUtil.logInAs("user");
         //when
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
-                                                                                                      50));
+                                                                                                      200));
         //then
         assertThat(processDefinitionPage.getContent()).isNotNull();
         assertThat(processDefinitionPage.getContent())

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/mainProcessCallActivity.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/mainProcessCallActivity.bpmn20.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+    <bpmn2:process id="mainProcess-843144bc-3797-40db-8edc-d23190b1183h" name="parentProcess" isExecutable="true">
+        <bpmn2:documentation />
+        <bpmn2:startEvent id="StartEvent_1">
+            <bpmn2:outgoing>SequenceFlow_0o4nqgc</bpmn2:outgoing>
+        </bpmn2:startEvent>
+        <bpmn2:callActivity id="CallActivity_06e5v7z" calledElement="parentproc-843144bc-3797-40db-8edc-d23190b118e3">
+            <bpmn2:incoming>SequenceFlow_0o4nqgc</bpmn2:incoming>
+            <bpmn2:outgoing>SequenceFlow_1b7yk0g</bpmn2:outgoing>
+        </bpmn2:callActivity>
+        <bpmn2:sequenceFlow id="SequenceFlow_0o4nqgc" sourceRef="StartEvent_1" targetRef="CallActivity_06e5v7z" />
+        <bpmn2:endEvent id="EndEvent_18yg7b9">
+            <bpmn2:incoming>SequenceFlow_1b7yk0g</bpmn2:incoming>
+        </bpmn2:endEvent>
+        <bpmn2:sequenceFlow id="SequenceFlow_1b7yk0g" sourceRef="CallActivity_06e5v7z" targetRef="EndEvent_18yg7b9" />
+    </bpmn2:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mainProcess-843144bc-3797-40db-8edc-d23190b1183h">
+            <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+                <dc:Bounds x="412" y="240" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="CallActivity_06e5v7z_di" bpmnElement="CallActivity_06e5v7z">
+                <dc:Bounds x="510" y="218" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="SequenceFlow_0o4nqgc_di" bpmnElement="SequenceFlow_0o4nqgc">
+                <di:waypoint x="448" y="258" />
+                <di:waypoint x="510" y="258" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="479" y="236" width="0" height="13" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="EndEvent_18yg7b9_di" bpmnElement="EndEvent_18yg7b9">
+                <dc:Bounds x="672" y="240" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="690" y="279" width="0" height="13" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="SequenceFlow_1b7yk0g_di" bpmnElement="SequenceFlow_1b7yk0g">
+                <di:waypoint x="610" y="258" />
+                <di:waypoint x="672" y="258" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="641" y="236" width="0" height="13" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-core/pom.xml
+++ b/activiti-core/pom.xml
@@ -16,7 +16,7 @@
     <commons-email.version>1.6.0</commons-email.version>
     <commons-io.version>2.14.0</commons-io.version>
     <commons-text.version>1.13.0</commons-text.version>
-    <jakarta-enterprise-concurrent.version>1.1.2</jakarta-enterprise-concurrent.version>
+    <jakarta-enterprise-concurrent.version>3.1.1</jakarta-enterprise-concurrent.version>
     <java-uuid-generator.version>5.1.0</java-uuid-generator.version>
     <javaGeom.version>0.11.1</javaGeom.version>
     <jgraphx.version>4.2.2</jgraphx.version>

--- a/activiti-core/pom.xml
+++ b/activiti-core/pom.xml
@@ -20,7 +20,7 @@
     <java-uuid-generator.version>5.1.0</java-uuid-generator.version>
     <javaGeom.version>0.11.1</javaGeom.version>
     <jgraphx.version>4.2.2</jgraphx.version>
-    <joda-time.version>2.12.0</joda-time.version>
+    <joda-time.version>2.13.1</joda-time.version>
     <json-unit.version>4.1.0</json-unit.version>
     <mybatis.version>3.5.17</mybatis.version>
     <subethasmtp-wiser.version>1.2</subethasmtp-wiser.version>

--- a/activiti-core/pom.xml
+++ b/activiti-core/pom.xml
@@ -15,7 +15,7 @@
     <batik.version>1.18</batik.version>
     <commons-email.version>1.6.0</commons-email.version>
     <commons-io.version>2.14.0</commons-io.version>
-    <commons-text.version>1.12.0</commons-text.version>
+    <commons-text.version>1.13.0</commons-text.version>
     <jakarta-enterprise-concurrent.version>1.1.2</jakarta-enterprise-concurrent.version>
     <java-uuid-generator.version>5.1.0</java-uuid-generator.version>
     <javaGeom.version>0.11.1</javaGeom.version>

--- a/activiti-core/pom.xml
+++ b/activiti-core/pom.xml
@@ -13,7 +13,7 @@
   <name>Activiti :: Core :: Parent</name>
   <properties>
     <batik.version>1.18</batik.version>
-    <commons-email.version>1.5</commons-email.version>
+    <commons-email.version>1.6.0</commons-email.version>
     <commons-io.version>2.14.0</commons-io.version>
     <commons-text.version>1.12.0</commons-text.version>
     <jakarta-enterprise-concurrent.version>1.1.2</jakarta-enterprise-concurrent.version>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <!-- versions -->
     <asm.version>9.7.1</asm.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
-    <dependency-check-maven.version>8.4.3</dependency-check-maven.version>
+    <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
     <third-party-license-maven-plugin.version>2.5.0</third-party-license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
-    <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
+    <maven-clean-plugin.version>3.4.1</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
-    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
-    <third-party-license-maven-plugin.version>2.0.1.alfresco-2</third-party-license-maven-plugin.version>
+    <third-party-license-maven-plugin.version>2.5.0</third-party-license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-    <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
     <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `873bcdf..2e83cfb`
**Files Changed:** 28 (23 programming files)
**Programming Ratio:** 82.1%

**Commits included:**
- AAE-32998 Fix MultiInstanceExport (#4988)
- AAE-33087 Add root process instance id in ProcessInstance (#4964)
- AAE-33097 Allow jsonpatch for arrays (#4980)
- build(deps): bump jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api from 1.1.2 to 3.1.1 (#4825)
- build(deps): bump org.apache.maven.plugins:maven-clean-plugin from 3.3.2 to 3.4.1 (#4976)
- build(deps): bump org.apache.maven.plugins:maven-deploy-plugin from 3.1.3 to 3.1.4 (#4978)
- AAE-33031 Fix Initiator not passed into call activity subprocess (#4958)
- AAE-33125 Add taskId getter in CompleteTaskCmd (#4967)
- AAE-33103 Fix ignored pagination in process definition search endpoint (#4965)
- build(deps): bump org.apache.maven.plugins:maven-failsafe-plugin from 2.22.2 to 3.5.2 (#4913)
... and 5 more commits